### PR TITLE
distinguish event types

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -26,6 +26,14 @@
                 style="color:orangered">T</span><span style="color: yellow">R</span><span
                 style="color: deepskyblue">E</span><span style="color: green">A</span><span style="color: orchid">M</span></a></div>
     </div>
+    <div class="list-wrapper">
+            <h2>Calendar Key</h2>
+            <ul class="calendar-key">
+                <li><span class="key-dot active"></span>Today</li>
+                <li><span class="key-dot event"></span>Mainstream Event</li>
+                <li><span class="key-dot kenna"></span>Kenna Event</li>
+            </ul>
+        </div>
     <div class="content-wrapper">
         <div class="calendar-container">
             <header class="calendar-header">
@@ -52,6 +60,7 @@
                 <ul class="calendar-dates"></ul>
             </div>
         </div>
+        
         <div class="list-wrapper">
             <h2>Upcoming Events</h2>
             <div class="events-list">

--- a/css/calendar.css
+++ b/css/calendar.css
@@ -133,6 +133,10 @@ header .calendar-current-date {
     background: #6332c5;
 }
 
+.calendar-dates li.kenna::before {
+    background: #ffa600;
+}
+
 .calendar-dates li.event::before {
     background: #00bfff;
 }
@@ -198,7 +202,6 @@ header .calendar-current-date {
     font-size: 6em;
     text-align: center;
 }
-
 
 @media (max-width: 880px) {
     .title

--- a/css/calendar.css
+++ b/css/calendar.css
@@ -9,6 +9,7 @@
 
 body {
     font-family: 'Poppins', sans-serif;
+    background: purple;
 }
 
 
@@ -143,6 +144,37 @@ header .calendar-current-date {
 
 .calendar-dates li.event:hover::before {
     background: #000;
+}
+
+.calendar-key {
+    list-style: none;
+    padding: 10px;
+}
+
+.calendar-key li {
+    display: flex;
+    align-items: center;
+    margin: 5px 0;
+}
+
+.key-dot {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    margin-right: 10px;
+}
+
+.key-dot.active {
+    background: #6332c5;
+}
+
+.key-dot.event {
+    background: #00bfff;
+}
+
+.key-dot.kenna {
+    background: #ffa600;
 }
 /* end calendar */
 

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1,18 +1,26 @@
 // list of dictionaries that describe events on the calendar
 const events = [
-    { "date": "2024-6-1", "title": "Quesos", "time": "6:30p","description": "Sidestream is coming to Quesos in Plainfield, IN!", "link": "https://cl.ison24.com/#/sn/newRv?id=3e5709f8-12b9-11ee-b5f3-02915a867417" },
-    { "date": "2024-6-8", "title": "Inspire Music Collective", "time": "6:30p","description": "Mainstream is partnering with Inspire Music Collective", "link": "https://www.inspiremusiccollective.org/events-1" },
-    { "date": "2024-6-12", "title": "Ale Emporium (Fishers)", "time": "8:30p","description": "The Sidestream duo will be entertaining dinnergoers all night long!", "link": "https://aleemporium.securetree.com/Locations/Fishers/" },
-    { "date": "2024-6-14", "title": "Ale Emporium (Fishers)", "time": "8:30p","description": "The Sidestream duo will be entertaining dinnergoers all night long!", "link": "https://aleemporium.securetree.com/Locations/Fishers/" },
-    { "date": "2024-6-15", "title": "Kilroy's Bar & Grill (Broad Ripple)", "time": "8:00p","description": "Sidestream will be playing on the patio outside. It's sure to be a hot night of music!", "link": "https://www.kilroysindy.com" },
-    { "date": "2024-6-22", "title": "The Social View", "time": "8:00p","description": "Mainstream is keeping the dinnertime vibes at The Social View.", "link": "#" },
-    { "date": "2024-7-6", "title": "Live on the Lake @ Cicero", "time": "6:00p", "description": "Catch Mainstream in an all-exclusive laketop performance. The band will be set up on a pontoon in Cicero's Morse Reservoir, floating around spreading positivity through music.", "link": "#" },
-    { "date": "2024-7-7", "title": "The Garage", "time": "4:00p", "description": "Mainstream is coming to The Garage downtown to rock & roll with the people!", "link": "https://www.garageindy.com/entertainment" },
-    { "date": "2024-7-20", "title": "Britton Tavern", "time": "10:00p", "description": "Mainstream will be at the Britton Tavern to rock & roll all night!", "link": "https://thebrittontavern.co/calendar" },
-    { "date": "2024-8-3", "title": "Ale Emporium (Greenwood)", "time": "8:30p", "description": "Mainstream will be entertaining dinnergoers all night long!", "link": "https://aleemporium.securetree.com/Locations/Greenwood/" },
-    { "date": "2024-11-8", "title": "Ale Emporium (Greenwood)", "time": "8:30p", "description": "Mainstream will be entertaining dinnergoers all night long!", "link": "https://aleemporium.securetree.com/Locations/Greenwood/" },
-    { "date": "2025-1-16", "title": "The Garage Indy", "time": "6:00p", "description": "The Mainstream trio will be centerstage at the Garage 'til 8pm!", "link": "https://www.garageindy.com/entertainment" },
-    { "date": "2025-2-23", "title": "Battle of the Bands @ Britton Tavern", "time": "8:40p", "description": "Come see Mainstream perform in this epic Battle of the Bands; Performers go all-in to see who's got the best crowd response! Come make some noise!!", "link": "https://thebrittontavern.co/calendar" },
+    { "date": "2024-6-1", "title": "Quesos", "time": "6:30p","description": "Sidestream is coming to Quesos in Plainfield, IN!", "link": "https://cl.ison24.com/#/sn/newRv?id=3e5709f8-12b9-11ee-b5f3-02915a867417", "type": "event" },
+    { "date": "2024-6-8", "title": "Inspire Music Collective", "time": "6:30p","description": "Mainstream is partnering with Inspire Music Collective", "link": "https://www.inspiremusiccollective.org/events-1", "type": "event"},
+    { "date": "2024-6-12", "title": "Ale Emporium (Fishers)", "time": "8:30p","description": "The Sidestream duo will be entertaining dinnergoers all night long!", "link": "https://aleemporium.securetree.com/Locations/Fishers/", "type": "event"},
+    { "date": "2024-6-14", "title": "Ale Emporium (Fishers)", "time": "8:30p","description": "The Sidestream duo will be entertaining dinnergoers all night long!", "link": "https://aleemporium.securetree.com/Locations/Fishers/", "type": "event"},
+    { "date": "2024-6-15", "title": "Kilroy's Bar & Grill (Broad Ripple)", "time": "8:00p","description": "Sidestream will be playing on the patio outside. It's sure to be a hot night of music!", "link": "https://www.kilroysindy.com", "type": "event"},
+    { "date": "2024-6-22", "title": "The Social View", "time": "8:00p","description": "Mainstream is keeping the dinnertime vibes at The Social View.", "link": "#", "type": "event"},
+    { "date": "2024-7-6", "title": "Live on the Lake @ Cicero", "time": "6:00p", "description": "Catch Mainstream in an all-exclusive laketop performance. The band will be set up on a pontoon in Cicero's Morse Reservoir, floating around spreading positivity through music.", "link": "#", "type": "event"},
+    { "date": "2024-7-7", "title": "The Garage", "time": "4:00p", "description": "Mainstream is coming to The Garage downtown to rock & roll with the people!", "link": "https://www.garageindy.com/entertainment", "type": "event"},
+    { "date": "2024-7-20", "title": "Britton Tavern", "time": "10:00p", "description": "Mainstream will be at the Britton Tavern to rock & roll all night!", "link": "https://thebrittontavern.co/calendar", "type": "event"},
+    { "date": "2024-8-3", "title": "Ale Emporium (Greenwood)", "time": "8:30p", "description": "Mainstream will be entertaining dinnergoers all night long!", "link": "https://aleemporium.securetree.com/Locations/Greenwood/", "type": "event"},
+    { "date": "2024-11-8", "title": "Ale Emporium (Greenwood)", "time": "8:30p", "description": "Mainstream will be entertaining dinnergoers all night long!", "link": "https://aleemporium.securetree.com/Locations/Greenwood/", "type": "event"},
+    { "date": "2025-1-16", "title": "The Garage Indy", "time": "6:00p", "description": "The Mainstream trio will be centerstage at the Garage 'til 8pm!", "link": "https://www.garageindy.com/entertainment", "type": "event"},
+    { "date": "2025-1-18", "title": "Del Friscos", "time": "6:00p", "description": "Kenna will be entertaining dinnergoes with smooth vibes & classic hits until 10p.", "link": "https://www.delfriscos.com/location/del-friscos-double-eagle-steakhouse-indianapolis-in/", "type": "kenna"},
+    { "date": "2025-1-23", "title": "Del Friscos", "time": "5:00p", "description": "Kenna will be entertaining dinnergoes with smooth vibes & classic hits until 9p.", "link": "https://www.delfriscos.com/location/del-friscos-double-eagle-steakhouse-indianapolis-in/", "type": "kenna" },
+    { "date": "2025-1-30", "title": "Del Friscos", "time": "5:00p", "description": "Kenna will be entertaining dinnergoes with smooth vibes & classic hits until 9p.", "link": "https://www.delfriscos.com/location/del-friscos-double-eagle-steakhouse-indianapolis-in/", "type": "kenna" },
+    { "date": "2025-2-8", "title": "The Garage Indy", "time": "6:00p", "description": "The Mainstream trio will be centerstage at the Garage 'til 8pm!", "link": "https://www.garageindy.com/entertainment", "type": "event" },
+    { "date": "2025-2-13", "title": "Del Friscos", "time": "5:00p", "description": "Kenna will be entertaining dinnergoes with smooth vibes & classic hits until 9p.", "link": "https://www.delfriscos.com/location/del-friscos-double-eagle-steakhouse-indianapolis-in/", "type": "kenna" },
+    { "date": "2025-2-14", "title": "Del Friscos", "time": "5:00p", "description": "Kenna will be entertaining dinnergoes with smooth vibes & classic hits until 9p.", "link": "https://www.delfriscos.com/location/del-friscos-double-eagle-steakhouse-indianapolis-in/", "type": "kenna" },
+    { "date": "2025-2-21", "title": "The Garage Indy", "time": "6:00p", "description": "The Mainstream trio will be centerstage at the Garage 'til 8pm!", "link": "https://www.garageindy.com/entertainment", "type": "event" },
+    { "date": "2025-2-27", "title": "The Garage Indy", "time": "6:00p", "description": "The Mainstream trio will be centerstage at the Garage 'til 8pm!", "link": "https://www.garageindy.com/entertainment", "type": "event" },
+    { "date": "2025-2-23", "title": "Battle of the Bands @ Britton Tavern", "time": "8:40p", "description": "Come see Mainstream perform in this epic Battle of the Bands; Performers go all-in to see who's got the best crowd response! Come make some noise!!", "link": "https://thebrittontavern.co/calendar", "type": "event"},
 ]
 
 
@@ -57,18 +65,19 @@ const manipulate = () => {
     for (let i = 1; i <= lastdate; i++) {
 
         let style;
+        let title = "";
+        let url = "";
         
         if (i === new Date().getDate() && year === new Date().getFullYear() && month === new Date().getMonth()) {
             style = "active"
         } else if (events.some(event => event.date == `${year}-${month + 1}-${i}`)) {
-            style = "event"
+            style = events.find(event => event.date == `${year}-${month + 1}-${i}`).type;
             title = events.find(event => event.date == `${year}-${month + 1}-${i}`).description;
             url = events.find(event => event.date == `${year}-${month + 1}-${i}`).link;
         } else {
             style = ""
-            url = "#"
         }
-        console.log("creating event", style, title, url)
+        //console.log("creating event", style, title, url)
         lit += `<li class="${style}" title="${title}" onclick="window.open('${(url?url:"#")}')">${i}</li>`;
     }
 


### PR DESCRIPTION
differentiate kenna dates vs mainstream dates
---
- doing this to spice up the calendar a bit
- changes include addition of `type` member to `events` object. later implementing logic to apply a separate (new) css class of the orange variety 👏🏼